### PR TITLE
Add horizontal line and copyright to footline

### DIFF
--- a/beamerthemesuse.sty
+++ b/beamerthemesuse.sty
@@ -91,7 +91,14 @@
 \setbeamertemplate{footline}[text line]{%
   \ifnum \theframenumber=1
   \else
-  \parbox{\linewidth}{\vspace*{-0.10\paperheight}\insertpagenumber\hfill}
+  \parbox{\linewidth}{
+    \vspace*{-0.10\paperheight}
+    \insertpagenumber
+    \hspace{3em}
+    {\color{SUSEJungle}\rule{4em}{.6pt}}
+    \hspace{2em}
+    Copyright \textcopyright\  SUSE 2020\hfill
+  }
   \fi
 }
 


### PR DESCRIPTION
Following the PowerPoint/Impress templates, this PR adds the copyright text to the frame footer.

Example:
![image](https://user-images.githubusercontent.com/1128117/96240506-47948880-0fa1-11eb-842f-6aab0614321c.png)
