### PR TITLE
Set explicit font variations for italic, bold and bold italic

### DIFF
--- a/beamerthemesuse.sty
+++ b/beamerthemesuse.sty
@@ -7,10 +7,10 @@
 \RequirePackage{textpos}
 
 % fonts
-\setmainfont{WorkSans-Light}
-\setsansfont{WorkSans-Light}
+\setmainfont{WorkSans-Light}[BoldFont=WorkSans-Medium, ItalicFont=WorkSans-LightItalic, BoldItalicFont=WorkSans-MediumItalic]
+\setsansfont{WorkSans-Light}[BoldFont=WorkSans-Medium, ItalicFont=WorkSans-LightItalic, BoldItalicFont=WorkSans-MediumItalic]
 \setmonofont{Inconsolata}
-\setbeamerfont{title page}{family=\fontspec{WorkSans-Regular}}
+\setbeamerfont{title page}{family=\fontspec{WorkSans-Medium}}
 
 % colors
 \definecolor{SUSEPine}{RGB}{12, 50, 44}


### PR DESCRIPTION
When explicitly using statements like `\textbf` or `\textit{}` it would be great, if that text got rendered differently.

Using the Google font "Work Sans" the result of this change would look like this:

![image](https://user-images.githubusercontent.com/1128117/96584871-1c7ea180-12df-11eb-909b-fc71585eed1a.png)
