### PR TITLE
Use lualatex to fix PDF creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: example.pdf
 
 %.pdf : %.tex
-	xelatex -interaction=nonstopmode $<
+	lualatex -interaction=nonstopmode $<
 
 screenshots: example-0.png example-1.png example-2.png
 


### PR DESCRIPTION
Even `google-worksans-fonts` package is installed, `xelatex` fails with:

```
xdvipdfmx:fatal: Cannot proceed without the font: /usr/share/fonts/truetype/WorkSans-Medium.woff
```

Although PDF is created, it's invalid.