### PR TITLE
Show frame number instead of page number.

### DIFF
--- a/beamerthemesuse.sty
+++ b/beamerthemesuse.sty
@@ -118,7 +118,7 @@
     \hfill
     \llap
     {
-      \textbf{\insertpagenumber}
+      \textbf{\theframenumber}
     }
     \vspace*{0.05\paperheight}
   }


### PR DESCRIPTION
Otherwise page number shown in the bottom increases after every part of the animation (itemized items appearing etc.).